### PR TITLE
prevent InvalidParameterCombination error

### DIFF
--- a/aws/eni.go
+++ b/aws/eni.go
@@ -286,7 +286,6 @@ func (c *ENIClient) GrabENI(p *GrabENIParam, wp *WaiterParam) (*model.ENI, error
 func (c *ENIClient) DescribeInstanceByID(instanceID string) (*model.Instance, error) {
 	p := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
-		MaxResults:  aws.Int64(1),
 	}
 	resp, err := c.svc.DescribeInstances(p)
 	if err != nil {


### PR DESCRIPTION
"You cannot specify this parameter and the instance IDs parameter" https://github.com/aws/aws-sdk-go/blob/87b1e60a50b09e4812dee560b33a238f67305804/service/ec2/api.go#L12467-L12469

```
[~/.go/src/github.com/yuuki1/grabeni]$ ./grabeni status eni-xxxxxxxx
error: InvalidParameterCombination: The parameter instancesSet cannot be used with the parameter maxResults
        status code: 400, request id:
```

 aws/eni.go内のDescribeInstanceByIDにて、常に上記InvalidParameterCombination エラーが出ていたのでそちらの対処です。
