### PR TITLE
do not get instance info if eni is not attached.

### DIFF
--- a/aws/eni.go
+++ b/aws/eni.go
@@ -89,7 +89,13 @@ func (c *ENIClient) DescribeENIByID(InterfaceID string) (*model.ENI, error) {
 	}
 
 	eni := model.NewENI(resp.NetworkInterfaces[0])
-	instance, err := c.DescribeInstanceByID(eni.AttachedInstanceID())
+	instanceId := eni.AttachedInstanceID()
+
+	// eni is not attached
+	if instanceId == "" {
+		return eni, nil
+	}
+	instance, err := c.DescribeInstanceByID(instanceId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If target eni is not attached, error occured when get instance info. Such as:

```
[~/.go/src/github.com/yuuki1/grabeni]$ ./grabeni status eni-xxxxxxxx
error: MissingParameter: The request must contain the parameter InstanceId
        status code: 400, request id:
```
